### PR TITLE
Improve flow layout when nodes labels are hidden

### DIFF
--- a/index.js
+++ b/index.js
@@ -1510,7 +1510,10 @@ const FlowRenderer = (function () {
 
                 // get node dimensions
                 var dimensions = getNodeDimensions(obj)
+                /** flag to indicate node should be full size or collapsed */
                 const showLabel = showsLabel(obj)
+                /** flag to indicate node labels should be hidden (but node size rendered as it would be with a label */
+                const hideLabels = !renderOpts.labels
 
                 // get node color
                 var clr = getNodeColor(obj.type);
@@ -1692,7 +1695,8 @@ const FlowRenderer = (function () {
                     default: {
                         /* the type of the node that represents a subflow is subflow:XXXX while the subflow has type 'subflow' */
                         const grpTextId = "grpTxt" + Math.random().toString().substring(2)
-                        const lblFunct = renderOpts.labels ? (labelByFunct[obj.type] || labelByFunct["_default"]) : emptyLabelFunct
+                        // const lblFunct = renderOpts.labels ? (labelByFunct[obj.type] || labelByFunct["_default"]) : emptyLabelFunct
+                        const lblFunct = (labelByFunct[obj.type] || labelByFunct["_default"])
                         const subflowObj = subflows[obj.type] || {}
                         const textLabels = getLabelParts(lblFunct(obj, subflowObj, flow), "node-text-label")
 
@@ -1741,6 +1745,9 @@ const FlowRenderer = (function () {
                                     grpText.setAttributeNS(null, "transform", "translate(38," + ((textLabels.lines.length > 1 ? 16 : 14) + offsetHeight) + ")")
                                 }
                             }
+                        }
+                        if (hideLabels && grpText) {
+                            grpText.style.display = "none"
                         }
                         // main rect of node
                         grpObj.prepend(createSvgElement('rect', {


### PR DESCRIPTION
closes #17

## Description

Improve flow layout when nodes labels are hidden by rendering them then hiding them.

### before
![image](https://github.com/FlowFuse/flow-renderer/assets/44235289/3764e237-2a71-4063-9022-fa48827d9b27)


### after

![image](https://github.com/FlowFuse/flow-renderer/assets/44235289/317e0deb-e36c-4660-996a-455d88f15771)


## Related Issue(s)

#17

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

