### PR TITLE
Add transport buttons for mobile zooming and copy/download

### DIFF
--- a/demo-esm.html
+++ b/demo-esm.html
@@ -8,12 +8,12 @@
     <style>
         div.flow-renderer {
             width: 100%;
-            height: 280px;
+            height: 320px;
         }
 
         #nr-flow-3 {
             width: 100%;
-            height: 280px;
+            height: 320px;
         }
 
         h1, h2, h3, h4, h5 {
@@ -43,15 +43,9 @@
     <h4>Render (grid, images, labels)</h4>
     <div id="nr-flow-1" class="flow-renderer"></div>
 
-    <br>
-    <br>
-
     <!-- Demo 2 -->
     <h4>Render (no grid, no images, labels)</h4>
-    <div id="nr-flow-2" class="different-class" style="width: auto; height: 280px;"></div>
-
-    <br>
-    <br>
+    <div id="nr-flow-2" class="different-class" style="width: auto; height: 320px;"></div>
 
     <!-- Demo 3 -->
     <h4>Render (no grid, images, no labels) using data-options</h4>

--- a/demo-vanilla.html
+++ b/demo-vanilla.html
@@ -8,12 +8,12 @@
     <style>
         div.flow-renderer {
             width: 100%;
-            height: 280px;
+            height: 320px;
         }
 
         #nr-flow-3 {
             width: 100%;
-            height: 280px;
+            height: 320px;
         }
 
         h1, h2, h3, h4, h5 {
@@ -43,15 +43,9 @@
     <h4>Render (grid, images, labels)</h4>
     <div id="nr-flow-1" class="flow-renderer"></div>
 
-    <br>
-    <br>
-
     <!-- Demo 2 -->
     <h4>Render (no grid, no images, labels)</h4>
-    <div id="nr-flow-2" class="different-class" style="width: auto; height: 280px;"></div>
-
-    <br>
-    <br>
+    <div id="nr-flow-2" class="different-class" style="width: auto; height: 320px;"></div>
 
     <!-- Demo 3 -->
     <h4>Render (no grid, images, no labels) using data-options</h4>

--- a/demo-vue.html
+++ b/demo-vue.html
@@ -8,12 +8,12 @@
     <style>
         div.flow-renderer {
             width: 100%;
-            height: 280px;
+            height: 320px;
         }
 
         #nr-flow-3 {
             width: 100%;
-            height: 280px;
+            height: 320px;
         }
 
         h1, h2, h3, h4, h5 {
@@ -39,21 +39,15 @@
         <button @click="render()">Render Flows</button>
         <button @click="render([])">Clear Flows</button>
         <br>
-    
+
         <!-- Demo 1 -->
         <h4>Render (grid, images, labels)</h4>
         <div ref="f1" class="flow-renderer"></div>
-    
-        <br>
-        <br>
-    
+
         <!-- Demo 2 -->
         <h4>Render (no grid, no images, labels)</h4>
-        <div ref="f2" class="different-class" style="width: auto; height: 280px;"></div>
-    
-        <br>
-        <br>
-    
+        <div ref="f2" class="different-class" style="width: auto; height: 320px;"></div>
+
         <!-- Demo 3 -->
         <h4>Render (no grid, images, no labels) using data-options</h4>
         <div ref="f3" id="nr-flow-3" data-grid-lines="false" data-labels="false" data-images></div>


### PR DESCRIPTION
closes #10
closes #8


## Description

* Adds toolbar with zoom, copy and download buttons
  * This is MVP in that it allow mobile users to operate zoom via buttons and in that the buttons are "text" only (no additional icons imported)
* Improves div size by taking tabs into account
  * SVG container div was oversizing when tabs present, causing integration layout issues
* Updates demo pages (remove the hacky BRs)
  * Now that the container div is not oversizing

### Demo of transport buttons
![chrome_k0Q25F6Ydd](https://github.com/FlowFuse/flow-renderer/assets/44235289/f948790b-4895-451d-bc5e-26cf8b20df31)



## Related Issue(s)

#10
#8

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

