### PR TITLE
Add tooltips to nodes for better identification of unknown node types

### DIFF
--- a/index.js
+++ b/index.js
@@ -3869,6 +3869,21 @@ const FlowRenderer = function () {
             })
         }
 
+        // add a tooltip of the node type to each node
+        // This is useful for identifying unknown node types that currently appear as white nodes
+        flow_nodesEl.querySelectorAll('.node').forEach(function (node) {
+            const nodeId = node.getAttribute('data-node-id')
+            const nde = nodes[nodeId]
+            if (nde) {
+                const type = nde.type
+                const subflowObj = subflows[type] || {}
+                const tooltip = subflowObj.label || type
+                const titleEl = createSvgElement('title')
+                titleEl.textContent = tooltip
+                node.appendChild(titleEl)
+            }
+        })
+
         /* finally remove our changes to the objects in the flowData array */
         flow.forEach(function (obj) { delete obj.bbox })
 


### PR DESCRIPTION
## Description

Add a tooltip to each node so that users can see what type the node is (helps with unknown node types)

![chrome_XLpsijCPnV](https://github.com/user-attachments/assets/17d34271-df04-4c6c-9da6-f6ec678dbdd9)


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

