### PR TITLE
fix: include w/h in position diff comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -1485,8 +1485,8 @@ const FlowRenderer = function () {
                     }
                     if (diff.positionChanged[changeId]) {
                         otherChanges = false // position changes indicate no other changes
-                        const v1Obj = { x: numberOrNull(v1node.x), y: numberOrNull(v1node.y) }
-                        const v2Obj = { x: numberOrNull(v2node.x), y: numberOrNull(v2node.y) }
+                        const v1Obj = { x: numberOrNull(v1node.x), y: numberOrNull(v1node.y), w: numberOrNull(v1node.w), h: numberOrNull(v1node.h) }
+                        const v2Obj = { x: numberOrNull(v2node.x), y: numberOrNull(v2node.y), w: numberOrNull(v2node.w), h: numberOrNull(v2node.h) }
                         const v1ObjStr = JSON.stringify(v1Obj)
                         const v2ObjStr = JSON.stringify(v2Obj)
                         changes.push(...getItemDifferences(tab.id, changeId, 'position', 'positionChanged', v1ObjStr, v2ObjStr))


### PR DESCRIPTION
Closes #88

## Summary

- `generateDiff` correctly detects w/h changes and sets `positionChanged`, but `getTabChanges` only compared x/y — so nodes that only changed width/height (e.g. resized groups) produced zero diff entries and could not be highlighted in the compare viewer
- Include `w` and `h` in the position comparison objects so all four layout properties are diffed

## Test plan

- Compare two snapshots where a group node has been resized (w/h changed) but not moved (x/y unchanged)
- Verify the group appears in the change list and can be highlighted in the compare viewer